### PR TITLE
Adding main file name in package.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,25 @@
-node_modules
-bower_components
+###########################
+#WebStorm Files
+###########################
+.idea/
+
+###########################
+#Sublime Files
+###########################
 angular-typeahead.sublime-workspace
+
+###########################
+#NPM Files
+###########################
+node_modules/
+npm-debug.log
+
+###########################
+#Bower Files
+###########################
+bower_components
+
+###########################
+#Other Files
+###########################
 tmp_angular-typeahead.js

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.2.3",
   "subdomain": "Siyfion",
   "private": true,
+  "main": "angular-typeahead.js",
   "author": "siyfion@gmail.com",
   "description": "An Angular.js wrapper around the Twitter Typeahead library.",
   "contributors": [


### PR DESCRIPTION
Adding main file name in package.json, so require("angular-typeahead") will not throw 
Error: module "angular-typeahead" not found.